### PR TITLE
fix: reshape enum definitions

### DIFF
--- a/src/migrateCaseConventions.ts
+++ b/src/migrateCaseConventions.ts
@@ -1,50 +1,36 @@
+const MODEL_TOKEN = 'model';
+const ENUM_TOKEN = 'enum';
 
 export function migrateCaseConventions(file_contents: string, tableCaseConvention: CaseChange, fieldCaseConvention: CaseChange): [string?, Error?] {
-  const MODEL_TOKEN = 'model';
-  const END_MODEL_TOKEN = '}';
   const lines = file_contents.split('\n');
-  const [model_bounds, model_bounds_error] = getModelBounds(lines);
-  if (model_bounds_error) {
-    return [, model_bounds_error];
+
+  const [reshape_model_error] = reshapeModelDefinitions(lines)
+  if (reshape_model_error) {
+    return [, reshape_model_error];
   }
 
-  const [new_lines, reshape_models_error] = reshapeModels(lines);
-  if (reshape_models_error) {
-    return [, reshape_models_error];
+  const [reshaped_enum_map, reshape_enum_error] = reshapeEnumDefinitions(lines)
+  if (reshape_enum_error) {
+    return [, reshape_enum_error];
   }
 
-  return [new_lines!.join('\n'),];
-
-  function getModelBounds(lines: string[]): [[number, number][]?, Error?] {
-    const model_bounds: [number, number][] = [];
-    let within_model = false;
-    let boundary_cursor: [number, number] = [] as any;
-    for (const [index, line] of lines.entries()) {
-      if (!within_model && line.trim().startsWith(MODEL_TOKEN)) {
-        boundary_cursor.push(index);
-        within_model = true;
-      } else if (within_model && line.trim().endsWith(END_MODEL_TOKEN)) {
-        boundary_cursor.push(index);
-        model_bounds.push(boundary_cursor);
-        boundary_cursor = [] as any;
-        within_model = false;
-      }
-    }
-    if (within_model) {
-      return [, new Error(`model starting on line ${boundary_cursor[0]} did not end`)];
-    }
-    return [model_bounds,];
+  const [reshape_model_field_error] = reshapeModelFields(lines, reshaped_enum_map!);
+  if (reshape_model_field_error) {
+    return [, reshape_model_field_error];
   }
 
-  function reshapeModels(lines: string[]): [string[]?, Error?] {
+  return [lines!.join('\n'),];
+
+  function reshapeModelDefinitions(lines: string[]): [Error?] {
     const MODEL_DECLARATION_REGEX = /^\s*model\s+(?<model>\w+)\s*\{\s*/;
-    const FIELD_DECLARATION_REGEX = /^(\s*)(?<field>\w+)(\s+)(?<type>[\w+]+)(?<complications>[\[\]\?]*)(\s+.*\s*)?/;
-    const RELATION_ANNOTATION_REGEX = /(@relation\("?\w*"?,?\s*fields: \[)(?<fields>.*)(\],\s*references: \[)(?<references>.*)(\].*\))/;
-    const TABLE_INDEX_REGEX = /\@\@index\((?<fields>\[[\w\s,]+\])/;
-    const TABLE_UNIQUE_REGEX = /\@\@unique\((?<fields>\[[\w\s,]+\])/;
-    const TABLE_ID_REGEX = /\@\@id\((?<fields>\[[\w\s,]+\])/;
+    
+    const [model_bounds, model_bounds_error] = getDefinitionBounds(MODEL_TOKEN, lines);
+    if (model_bounds_error) {
+      return [model_bounds_error];
+    }
+
     let offset = 0;
-    for (let [start, end] of model_bounds!) {
+    for (let [start, _end] of model_bounds!) {
       start = start + offset;
       try {
         const model_declaration_line = MODEL_DECLARATION_REGEX.exec(lines[start]);
@@ -56,26 +42,84 @@ export function migrateCaseConventions(file_contents: string, tableCaseConventio
           offset += 1;
         }
       } catch (error) {
+        return [error as Error];
+      }
+    }
+
+    return []
+  }
+
+  function reshapeEnumDefinitions(lines: string[]): [Map<string, string>?, Error?] {
+    const ENUM_DECLARATION_REGEX = /^\s*enum\s+(?<enum>\w+)\s*\{\s*/;
+    const reshaped_enum_map = new Map<string, string>(); // Map<origin_enum_name, reshaped_enum_name>
+
+    const [enum_bounds, enum_bounds_error] = getDefinitionBounds(ENUM_TOKEN, lines);
+    if (enum_bounds_error) {
+      return [, enum_bounds_error];
+    }
+
+    for(const [start, _end] of enum_bounds!) {
+      try {
+        const enum_declaration_line = ENUM_DECLARATION_REGEX.exec(lines[start]);
+        const enum_name = enum_declaration_line!.groups!['enum'];
+        const reshaped_enum_name = tableCaseConvention(enum_name);
+        if (reshaped_enum_name !== enum_name) {
+          lines[start] = transformDeclarationName(lines[start], enum_name, tableCaseConvention);
+        }
+
+        reshaped_enum_map.set(enum_name, reshaped_enum_name);
+      } catch (error) {
         return [, error as Error];
       }
-      end = end + offset;
+    }
+
+    return [reshaped_enum_map]
+  }
+
+  function reshapeModelFields(lines: string[], reshaped_enum_map: Map<string, string>): [Error?] {
+    const FIELD_DECLARATION_REGEX = /^(\s*)(?<field>\w+)(\s+)(?<type>[\w+]+)(?<complications>[\[\]\?]*)(\s+.*\s*)?/;
+    const RELATION_ANNOTATION_REGEX = /(@relation\("?\w*"?,?\s*fields: \[)(?<fields>.*)(\],\s*references: \[)(?<references>.*)(\].*\))/;
+    const TABLE_INDEX_REGEX = /\@\@index\((?<fields>\[[\w\s,]+\])/;
+    const TABLE_UNIQUE_REGEX = /\@\@unique\((?<fields>\[[\w\s,]+\])/;
+    const TABLE_ID_REGEX = /\@\@id\((?<fields>\[[\w\s,]+\])/;
+
+    const [model_bounds, model_bounds_error] = getDefinitionBounds(MODEL_TOKEN, lines);
+    if (model_bounds_error) {
+      return [model_bounds_error];
+    }
+    
+    for (const [start, end] of model_bounds!) {
       for (let i = start; i < end; i++) {
         const field_declaration_line = FIELD_DECLARATION_REGEX.exec(lines[i]);
         if (field_declaration_line) {
-          let [search_term, chunk0, field_name, chunk2, field_type, chunk4, chunk5] = field_declaration_line;
-          let original_field_name = field_name;
-          field_name = fieldCaseConvention(field_name);
+          let [search_term, chunk0, original_field_name, chunk2, field_type, chunk4, chunk5] = field_declaration_line;
+          const renamed_field_name = fieldCaseConvention(original_field_name);
           let map_field_fragment = '';
-          if (field_name !== original_field_name && !lines[i].includes('@relation') && isPrimitive(field_type)) {
+
+          // Primitive field
+          if (
+            renamed_field_name !== original_field_name && 
+            !lines[i].includes('@relation') &&
+            isPrimitive(field_type)
+          ) {
             map_field_fragment = ` @map("${original_field_name}")`;
           }
-          if (!isPrimitive(field_type)) {
-            // this may have bugs...
+
+          // Exception field
+          const enum_name = reshaped_enum_map.get(field_type)
+          if (enum_name) {
+            // Enum field
+            field_type = enum_name;
+            map_field_fragment = ` @map("${original_field_name}")`;
+          } else if (!isPrimitive(field_type)) {
+            // Unhandled field type
             field_type = tableCaseConvention(field_type);
           }
-          lines[i] = lines[i].replace(search_term, [chunk0, field_name, chunk2, field_type, chunk4, chunk5,].join(''));
+
+          lines[i] = lines[i].replace(search_term, [chunk0, renamed_field_name, chunk2, field_type, chunk4, chunk5,].join(''));
           lines[i] += map_field_fragment;
         }
+
         const relation_annotation_line = RELATION_ANNOTATION_REGEX.exec(lines[i]);
         if (relation_annotation_line) {
           const [search_term, chunk0, fields, chunk2, references, chunk4] = relation_annotation_line!;
@@ -83,43 +127,60 @@ export function migrateCaseConventions(file_contents: string, tableCaseConventio
             .split(/,\s*/)
             .map(fieldCaseConvention)
             .join(', ');
-
           const updated_references = references
             .split(/,\s*/)
             .map(fieldCaseConvention)
             .join(', ');
           lines[i] = lines[i].replace(search_term, [chunk0, updated_fields, chunk2, updated_references, chunk4].join(''));
         }
+
         const table_unique_declaration_line = TABLE_UNIQUE_REGEX.exec(lines[i]);
         if (table_unique_declaration_line) {
           const field_names = table_unique_declaration_line!.groups!['fields'];
-          const updated_field_names = '[' + field_names
-            .split(/,\s*/)
-            .map(fieldCaseConvention)
-            .join(', ') + ']';
+          const updated_field_names = `[${field_names.split(/,\s*/).map(fieldCaseConvention).join(', ')}]`;
           lines[i] = lines[i].replace(field_names, updated_field_names);
         }
+
         const table_index_declaration_line = TABLE_INDEX_REGEX.exec(lines[i]);
         if (table_index_declaration_line) {
           const field_names = table_index_declaration_line!.groups!['fields'];
-          const updated_field_names = '[' + field_names
-            .split(/,\s*/)
-            .map(fieldCaseConvention)
-            .join(', ') + ']';
+          const updated_field_names = `[${field_names.split(/,\s*/).map(fieldCaseConvention).join(', ')}]`;
           lines[i] = lines[i].replace(field_names, updated_field_names);
         }
+
         const table_id_declaration_line = TABLE_ID_REGEX.exec(lines[i]);
         if (table_id_declaration_line) {
           const field_names = table_id_declaration_line!.groups!['fields'];
-          const updated_field_names = '[' + field_names
-            .split(/,\s*/)
-            .map(fieldCaseConvention)
-            .join(', ') + ']';
+          const updated_field_names = `[${field_names.split(/,\s*/).map(fieldCaseConvention).join(', ')}]`;
           lines[i] = lines[i].replace(field_names, updated_field_names);
         }
       }
     }
-    return [lines,];
+
+    return []
+  }
+
+  function getDefinitionBounds(token: string, lines: string[]): [[number, number][]?, Error?] {
+    const END_DEFINITION_TOKEN = '}';
+
+    const definition_bounds: [number, number][] = [];
+    let within_definition = false;
+    let boundary_cursor: [number, number] = [] as any;
+    for (const [index, line] of lines.entries()) {
+      if (!within_definition && line.trim().startsWith(token)) {
+        boundary_cursor.push(index);
+        within_definition = true;
+      } else if (within_definition && line.trim().endsWith(END_DEFINITION_TOKEN)) {
+        boundary_cursor.push(index);
+        definition_bounds.push(boundary_cursor);
+        boundary_cursor = [] as any;
+        within_definition = false;
+      }
+    }
+    if (within_definition) {
+      return [, new Error(`${token} starting on line ${boundary_cursor[0]} did not end`)];
+    }
+    return [definition_bounds,];
   }
 
   function transformDeclarationName(declaration_line: string, declaration_name: string, tableCaseConvention: CaseChange): string {
@@ -131,16 +192,16 @@ export type CaseChange = (input: string) => string;
 
 export function isPrimitive(field_type: string) {
   field_type = field_type.replace('[]', '').replace('?', '').replace(/("\w+")/, '');
-  return (
-    field_type === 'String'
-    || field_type === 'Boolean'
-    || field_type === 'Int'
-    || field_type === 'BigInt'
-    || field_type === 'Float'
-    || field_type === 'Decimal'
-    || field_type === 'DateTime'
-    || field_type === 'Json'
-    || field_type === 'Bytes'
-    || field_type === 'Unsupported'
-  );
+  return [
+    'String',
+    'Boolean',
+    'Int',
+    'BigInt',
+    'Float',
+    'Decimal',
+    'DateTime',
+    'Json',
+    'Bytes',
+    'Unsupported',
+  ].includes(field_type);
 }

--- a/test/migrateCaseConventions.test.ts
+++ b/test/migrateCaseConventions.test.ts
@@ -1,4 +1,4 @@
-const { camelCase, pascalCase } = require('change-case');
+const { camelCase, pascalCase, snakeCase } = require('change-case');
 const { migrateCaseConventions } = require('../src/migrateCaseConventions');
 
 test('it can map model columns with under_scores to camelCase', () => {
@@ -46,4 +46,31 @@ test('it can map relations with cascading deletion rules & foreign_key names', (
   const [result, err] = migrateCaseConventions(file_contents, pascalCase, camelCase);
   expect(err).toBeFalsy();
   expect(result.includes('@relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "jira_issues_projects_fkey")')).toBeTruthy();
+});
+
+test('it can map enum column to enum definition', () => {
+  const file_contents = `datasource db {
+    provider = "mysql"
+    url      = env("DATABASE_URL")
+  }
+  
+  generator client {
+    provider = "prisma-client-js"
+  }
+  
+  model posts {
+    id        Int           @id @default(autoincrement())
+    content   String?       @db.VarChar
+    postType  post_type
+  }
+
+  enum post_type {
+    Note
+    Question
+  }
+  `;
+  const [result, err] = migrateCaseConventions(file_contents, pascalCase, snakeCase);
+  expect(err).toBeFalsy();
+  expect(result.includes(`post_type  PostType @map("postType")`)).toBeTruthy();
+  expect(result.includes(`enum PostType {`)).toBeTruthy();
 });


### PR DESCRIPTION
### Summary

- reshape enum definitions
- reshape enum field type & map original field name
- PR that fixed issues (#6, #7)

ps. I recommend using `prettier` and `eslint` for a consistent code style, but it is optional.
