### PR TITLE
Doesnt break anymore if column has 'view' in name

### DIFF
--- a/src/convention-transformer.ts
+++ b/src/convention-transformer.ts
@@ -321,7 +321,7 @@ export class ConventionTransformer {
     let boundary_cursor: [number, number] = [] as any;
     for (const token of tokens) {
       for (const [index, line] of lines.entries()) {
-        if (!within_definition && line.trim().startsWith(token)) {
+        if (!within_definition && line.startsWith(token)) {
           boundary_cursor.push(index);
           within_definition = true;
         } else if (within_definition && line.trim().endsWith(END_DEFINITION_TOKEN)) {

--- a/test/__fixtures__/columns-with-view-in-name.schema.prisma
+++ b/test/__fixtures__/columns-with-view-in-name.schema.prisma
@@ -1,0 +1,13 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:database.db"
+}
+
+// generator
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Demo {
+  view_count Int
+}

--- a/test/convention-transformer.test.ts
+++ b/test/convention-transformer.test.ts
@@ -166,3 +166,16 @@ test('it can enforce a specified case convention on views', async () => {
   let new_schema = await formatSchema({ schema: schema! });
   expect(new_schema).toMatchSnapshot();
 });
+
+test('it can map columns with `view` in the name', () => {
+  const file_contents = getFixture('columns-with-view-in-name');
+
+  const opts = {
+    tableCaseConvention: pascalCase,
+    fieldCaseConvention: camelCase,
+    pluralize: false
+  };
+  const [result, err] = ConventionTransformer.migrateCaseConventions(file_contents, opts);
+  expect(err).toBeFalsy();
+  expect(result?.includes('viewCount Int @map("view_count")')).toBeTruthy();
+});


### PR DESCRIPTION
Fix suggestion for https://github.com/iiian/prisma-case-format/issues/23

The problem is that transformer tries to find `view` or `model` from start of the line to detect boundaries but it trims before the search so it will also match for columns that are indented with few spaces.

This fix assumes that  `view` or `model` is always found in the beginning of the line.