### PR TITLE
Relax map annotation regexes

### DIFF
--- a/src/convention-transformer.ts
+++ b/src/convention-transformer.ts
@@ -51,10 +51,10 @@ export function isPrimitive(field_type: string) {
 }
 
 const MODEL_DECLARATION_REGEX = /^\s*(model|view)\s+(?<model>\w+)\s*\{\s*/;
-const ENTITY_MAP_ANNOTATION_REGEX = /@@map\("(?<map>\w+)"\)/;
+const ENTITY_MAP_ANNOTATION_REGEX = /@@map\("(?<map>.+)"\)/;
 const ENUM_DECLARATION_REGEX = /^\s*enum\s+(?<enum>\w+)\s*\{\s*/;
 const FIELD_DECLARATION_REGEX = /^(\s*)(?<field>\w+)(\s+)(?<type>[\w+]+(\((?:[\w\s"'.]+(?:,\s*)?)*\))?)(?<is_array_or_nullable>[\[\]\?]*)(\s+.*\s*)?(?<comments>\/\/.*)?/;
-const MAP_ANNOTATION_REGEX = /@map\("(?<map>\w+)"\)/;
+const MAP_ANNOTATION_REGEX = /@map\("(?<map>.+)"\)/;
 const RELATION_ANNOTATION_REGEX = /(?<preamble>@relation\("?\w*"?,?\s*)((?<cue1>(fields|references):\s*\[)(?<ids1>\w+(,\s*\w+\s*)*))((?<cue2>\]\,\s*(fields|references):\s*\[)(?<ids2>\w+(,\s*\w+\s*)*))(?<trailer>\].*)/;
 const EZ_TABLE_INDEX_REGEX = /\@\@index\((?<fields>\[[\w\s,]+\])/;
 const CPLX_TABLE_INDEX_REGEX = /\@\@index.*/;


### PR DESCRIPTION
Resolves issue with duplicate map annotations due to regex not matching spaces, /, -, etc

---

Thanks for the tool! 

I'm working with an old SQL Server database and ran into some issues due to the regex not matching, here are some examples:

```
Group_Title  String? @map("Group Title") @db.NVarChar(250)
```

ends up as

```
groupTitle  String? @map("Group_Title") @map("Group Title") @db.NVarChar(250)
```

and

```
  @@map("foo-final")
```

as

```
  @@map("foo_final")
  @@map("foo-final")
```

---

Loosening the regex resolves this for me and doesn't generate a new attribute, not sure if you want it to be stricter as they should be valid if generated from prisma dump anyway.